### PR TITLE
Bumping PHP version and supporting PHP v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2|^8.0",
         "placidapp/placid-php": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bumped PHP version to v7.2 (minimum for Laravel 7) and added support for PHP v8.