### PR TITLE
Add php ^8.0 support & drop EOL versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.4|^8.0",
         "placidapp/placid-php": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Add PHP ^8.0 support
- Remove empty require-dev
- Fix critical non-existing functions and uses

Reference of EOL versions: https://www.php.net/supported-versions.php

Important: Before merge, be sure you merged https://github.com/placidapp/placid-php/pull/2 before this PR.